### PR TITLE
Skip version suffix on release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,12 +28,11 @@ jobs:
       - name: Upload module
         run: |
           set -e
-          export PACKAGE_NAME=$(basename ${{ github.repository }})
-          export VERSION=${{ github.ref_name }}
+          export PACKAGE_FILE=$(basename ${{ github.repository }}).tar.gz
           make package
           
           curl \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "Content-Type: application/gzip" \
-            --data-binary @out/${PACKAGE_NAME}-${VERSION}.tar.gz \
-            $UPLOAD_URL?name=${PACKAGE_NAME}-${VERSION}.tar.gz
+            --data-binary @out/${PACKAGE_FILE} \
+            $UPLOAD_URL?name=${PACKAGE_FILE}

--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ check-fmt:
 	find . -type f -name '*.tf' -or -name '*.tfvars' -or -name '*.tftest.hcl' | xargs -n1 terraform fmt -check -diff
 
 release:
-	gh release create $(VERSION) --title "Release $(VERSION)" --target release-skip-suffix --generate-notes
+	gh release create $(VERSION) --title "Release $(VERSION)" --target main --generate-notes

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
 PACKAGE_NAME ?= $(shell basename $(CURDIR))
-VERSION ?= v0.1.0
-COMMIT ?= $(shell git rev-parse HEAD)
+COMMIT ?= $(shell git rev-parse --short HEAD)
+VERSION ?= v0.1.0-$(COMMIT)
 
-PACKAGE_FILE=out/$(PACKAGE_NAME)-$(VERSION).tar.gz
+PACKAGE_FILE ?= $(PACKAGE_NAME)-$(VERSION).tar.gz
 
 .PHONY: default
 default: test
 
-$(PACKAGE_FILE):
+out/$(PACKAGE_FILE):
 	mkdir -p out
-	tar -czf $(PACKAGE_FILE) --exclude out --exclude Makefile --exclude .terraform --exclude '.git*' --exclude tests .
+	tar -czf out/$(PACKAGE_FILE) --exclude out --exclude Makefile --exclude .terraform --exclude '.git*' --exclude tests .
 
 .PHONY: package
-package: $(PACKAGE_FILE)
+package: out/$(PACKAGE_FILE)
 
 .PHONY: clean
 clean:
@@ -31,4 +31,4 @@ check-fmt:
 	find . -type f -name '*.tf' -or -name '*.tfvars' -or -name '*.tftest.hcl' | xargs -n1 terraform fmt -check -diff
 
 release:
-	gh release create $(VERSION) --title "Release $(VERSION)" --target main --generate-notes
+	gh release create $(VERSION) --title "Release $(VERSION)" --target release-skip-suffix --generate-notes


### PR DESCRIPTION
Including the version number in the release artifact name leads to the version number appearing twice in the resulting asset url (e.g. `https://github.com/joerx/terraform-linode-bucket/releases/download/v0.1.16/terraform-linode-bucket-v0.1.16.tar.gz`) - This PR omits the suffix in the release pipeline to remove the redundancy.